### PR TITLE
Feat: #6 entity 수정

### DIFF
--- a/src/main/java/com/example/coffee/common/Timestamped.java
+++ b/src/main/java/com/example/coffee/common/Timestamped.java
@@ -1,0 +1,22 @@
+package com.example.coffee.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class Timestamped {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/example/coffee/menu/entity/Menu.java
+++ b/src/main/java/com/example/coffee/menu/entity/Menu.java
@@ -1,5 +1,6 @@
 package com.example.coffee.menu.entity;
 
+import com.example.coffee.common.Timestamped;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,15 +9,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Menu {
+public class Menu extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 30)
+    @Column(length = 30, nullable = false)
     private String menuName;
 
-    @Column
+    @Column(nullable = false)
     private Integer menuPrice;
 }

--- a/src/main/java/com/example/coffee/order/entity/Order.java
+++ b/src/main/java/com/example/coffee/order/entity/Order.java
@@ -1,36 +1,34 @@
 package com.example.coffee.order.entity;
 
+import com.example.coffee.common.Timestamped;
 import com.example.coffee.menu.entity.Menu;
 import com.example.coffee.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
+@Table(name = "`ORDER`")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order {
+public class Order extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "USERS_ID", nullable = false)
+    @JoinColumn(name = "USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "MENU_ID", nullable = false)
+    @JoinColumn(name = "MENU_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Menu menu;
 
-    @Column
-    @CreatedDate
-    private LocalDateTime orderedAt;
+    @Column(nullable = false)
+    private String menuName;
+
+    @Column(nullable = false)
+    private int menuPrice;
 }

--- a/src/main/java/com/example/coffee/user/entity/PointTransaction.java
+++ b/src/main/java/com/example/coffee/user/entity/PointTransaction.java
@@ -1,29 +1,25 @@
 package com.example.coffee.user.entity;
 
+import com.example.coffee.common.Timestamped;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PointTransaction {
+public class PointTransaction extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
 
-    @Column
+    @Column(length = 10, nullable = false)
     @Enumerated(EnumType.STRING)
     private TransactionType type;
 
@@ -31,9 +27,5 @@ public class PointTransaction {
     private Long point;
 
     @Column
-    private Long totalPoint;
-
-    @Column
-    @CreatedDate
-    private LocalDateTime transactedAt;
+    private Long pointBalance;
 }

--- a/src/main/java/com/example/coffee/user/entity/User.java
+++ b/src/main/java/com/example/coffee/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.example.coffee.user.entity;
 
+import com.example.coffee.common.Timestamped;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -7,15 +8,15 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "USERS")
+@Table(name = "`USER`")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(length = 20, nullable = false, unique = true)
     private String username;
 
     @Column


### PR DESCRIPTION
- 수정된 ERD를 따라서 entity 수정
- `Timestamped` 추가하여 모든 테이블에 createdAt, modifiedAt 컬럼 추가
- FK 제약조건 제거 및 UK 제약조건 추가
- `User`, `Order` 테이블명이 예약어여서 @Table로 이름 직접 설정
- 컬럼 길이, nullable 등 세부사항 적용

closes #6