### PR TITLE
Feat: #12 인기 메뉴 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/coffee/config/QuerydslConfig.java
+++ b/src/main/java/com/example/coffee/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.coffee.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/coffee/menu/controller/MenuController.java
+++ b/src/main/java/com/example/coffee/menu/controller/MenuController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -24,12 +23,14 @@ public class MenuController {
     @GetMapping("/all-menus")
     @Operation(summary = "커피 메뉴 목록 조회", description = "메뉴 ID, 메뉴 이름, 메뉴 가격을 출력합니다.", tags = {"Menu"})
     List<MenuResponseDto> getAllMenus() {
+
         return menuService.getAllMenus();
     }
 
     @GetMapping("/popular-menus")
-    @Operation(summary = "인기 메뉴 목록 조회", description = "최근 7일간 인기있는 메뉴 3개(메뉴 이름, 주문 횟수)를 출력합니다.", tags = {"Menu"})
+    @Operation(summary = "인기 메뉴 목록 조회", description = "최근 7일간 인기있는 메뉴 3개(메뉴 ID, 메뉴 이름, 주문 횟수)를 출력합니다.", tags = {"Menu"})
     List<PopularMenuResponseDto> getPopularMenus() {
-        return new ArrayList<>();
+
+        return menuService.getPopularMenus();
     }
 }

--- a/src/main/java/com/example/coffee/menu/dto/PopularMenuResponseDto.java
+++ b/src/main/java/com/example/coffee/menu/dto/PopularMenuResponseDto.java
@@ -1,10 +1,27 @@
 package com.example.coffee.menu.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class PopularMenuResponseDto {
 
+    private Long menuId;
     private String menuName;
     private int orderCount;
+
+    @Builder
+    private PopularMenuResponseDto(Long menuId, String menuName, int orderCount) {
+        this.menuId = menuId;
+        this.menuName = menuName;
+        this.orderCount = orderCount;
+    }
+
+    public static PopularMenuResponseDto of(Long menuId, String menuName, int orderCount) {
+        return builder()
+                .menuId(menuId)
+                .menuName(menuName)
+                .orderCount(orderCount)
+                .build();
+    }
 }

--- a/src/main/java/com/example/coffee/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/coffee/menu/repository/MenuRepository.java
@@ -3,5 +3,5 @@ package com.example.coffee.menu.repository;
 import com.example.coffee.menu.entity.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MenuRepository extends JpaRepository<Menu, Long> {
+public interface MenuRepository extends JpaRepository<Menu, Long>, PopularMenuRepository {
 }

--- a/src/main/java/com/example/coffee/menu/repository/PopularMenuRepository.java
+++ b/src/main/java/com/example/coffee/menu/repository/PopularMenuRepository.java
@@ -1,0 +1,10 @@
+package com.example.coffee.menu.repository;
+
+import com.example.coffee.menu.dto.PopularMenuResponseDto;
+
+import java.util.List;
+
+public interface PopularMenuRepository {
+
+    List<PopularMenuResponseDto> findWeeklyTopThreeMenus();
+}

--- a/src/main/java/com/example/coffee/menu/repository/PopularMenuRepositoryImpl.java
+++ b/src/main/java/com/example/coffee/menu/repository/PopularMenuRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.example.coffee.menu.repository;
+
+import com.example.coffee.menu.dto.PopularMenuResponseDto;
+import com.example.coffee.menu.entity.QMenu;
+import com.example.coffee.order.entity.QOrder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class PopularMenuRepositoryImpl implements PopularMenuRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QOrder qOrder = QOrder.order;
+    private final QMenu qMenu = QMenu.menu;
+
+    @Override
+    public List<PopularMenuResponseDto> findWeeklyTopThreeMenus() {
+
+        LocalDateTime weekAgo = LocalDateTime.of(LocalDate.now().minusDays(6L), LocalTime.of(0, 0));
+        LocalDateTime now = LocalDateTime.now();
+
+        return jpaQueryFactory.select(qOrder.menu.id, qMenu.menuName, qOrder.count())
+                .from(qOrder)
+                .innerJoin(qOrder.menu, qMenu)
+                .where(qOrder.createdAt.between(weekAgo, now))
+                .groupBy(qOrder.menu.id)
+                .orderBy(qOrder.count().desc())
+                .limit(3)
+                .fetch()
+                .stream()
+                .map(tuple -> PopularMenuResponseDto.of(tuple.get(qOrder.menu.id), tuple.get(qMenu.menuName), tuple.get(qOrder.count()).intValue()))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/coffee/menu/service/MenuService.java
+++ b/src/main/java/com/example/coffee/menu/service/MenuService.java
@@ -1,6 +1,7 @@
 package com.example.coffee.menu.service;
 
 import com.example.coffee.menu.dto.MenuResponseDto;
+import com.example.coffee.menu.dto.PopularMenuResponseDto;
 import com.example.coffee.menu.repository.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,4 +22,8 @@ public class MenuService {
                 .toList();
     }
 
+    public List<PopularMenuResponseDto> getPopularMenus() {
+
+        return menuRepository.findWeeklyTopThreeMenus();
+    }
 }


### PR DESCRIPTION
- 최근 7일간 가장 많이 주문한 메뉴 3개 조회(메뉴 ID, 메뉴 이름, 주문 횟수)
- 메뉴 이름이 변경되는 경우도 고려하여 메뉴ID를 group by 하여 카운트 계산
- QueryDSL 사용을 위한 의존성 추가 및 설정
- 인기 메뉴 조회 Querydsl로 구현

closes #12